### PR TITLE
feat: update to 1.19.3

### DIFF
--- a/Solar's remake/pack.mcmeta
+++ b/Solar's remake/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 8,
+    "pack_format": 12,
     "description": "Solarflame's light armor"
   }
 }


### PR DESCRIPTION
NB: Not sure if there's a way to make this backwards-compatible with older versions too, I'm not too familiar with the pack meta format. If this value is any less than 12 it can't be imported on 1.19.3. Feel free to reject if there's a better way to do this.